### PR TITLE
Fix speech synthesis timing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,11 +15,13 @@ function App() {
   const startTimer = () => {
     setRunning(true)
     setSeconds(0)
+    // clear any queued speech before starting
+    window.speechSynthesis.cancel()
     intervalRef.current = setInterval(() => {
       setSeconds((prev) => {
         const next = prev + 1
-        window.speechSynthesis.cancel()
-        window.speechSynthesis.speak(new SpeechSynthesisUtterance(String(next)))
+        const utterance = new SpeechSynthesisUtterance(String(next))
+        window.speechSynthesis.speak(utterance)
         return next
       })
     }, 1000)


### PR DESCRIPTION
## Summary
- ensure queued speech is cleared once when timer starts
- speak each second using new utterance so numbers are audible

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890add468d08331a27fc9852e0ee796