### PR TITLE
Ensure speech synthesis voice is initialized before speaking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import './App.css'
 
 function App() {
@@ -11,9 +11,28 @@ function App() {
 
   const intervalRef = useRef(null)
   const recognitionRef = useRef(null)
+  const voiceRef = useRef(null)
+
+  // ensure voices are loaded before attempting to speak
+  useEffect(() => {
+    const loadVoices = () => {
+      const voices = window.speechSynthesis.getVoices()
+      if (voices.length > 0) {
+        voiceRef.current = voices[0]
+      }
+    }
+
+    // some browsers load voices asynchronously
+    window.speechSynthesis.addEventListener('voiceschanged', loadVoices)
+    loadVoices()
+    return () => {
+      window.speechSynthesis.removeEventListener('voiceschanged', loadVoices)
+    }
+  }, [])
 
   const speak = (text) => {
     const utterance = new SpeechSynthesisUtterance(text)
+    if (voiceRef.current) utterance.voice = voiceRef.current
     // make sure previous speech does not queue up
     window.speechSynthesis.cancel()
     window.speechSynthesis.speak(utterance)


### PR DESCRIPTION
## Summary
- load available SpeechSynthesis voices on mount
- use first loaded voice for timer announcements to restore audio output

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891a76f943083319fd10920958eb843