### PR TITLE
Improve voice control reliability and button layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,6 +10,29 @@ button {
   font-size: 1rem;
 }
 
+.start-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.start-count {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+.start-exercise {
+  background-color: #2196f3;
+  color: #fff;
+}
+
+.stop-button {
+  background-color: #f44336;
+  color: #fff;
+  margin-bottom: 1rem;
+}
+
 ul {
   list-style: none;
   padding: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ function App() {
   const intervalRef = useRef(null)
   const recognitionRef = useRef(null)
   const voiceRef = useRef(null)
+  const runningRef = useRef(running)
 
   // ensure voices are loaded before attempting to speak
   useEffect(() => {
@@ -29,6 +30,10 @@ function App() {
       window.speechSynthesis.removeEventListener('voiceschanged', loadVoices)
     }
   }, [])
+
+  useEffect(() => {
+    runningRef.current = running
+  }, [running])
 
   const speak = (text) => {
     const utterance = new SpeechSynthesisUtterance(text)
@@ -101,6 +106,9 @@ function App() {
       }
     }
     recognition.onerror = (e) => console.error(e)
+    recognition.onend = () => {
+      if (runningRef.current) recognition.start()
+    }
     recognitionRef.current = recognition
     recognition.start()
   }
@@ -108,9 +116,11 @@ function App() {
   return (
     <div>
       <h1>Exercise Timer</h1>
-      <button onClick={startTimer} disabled={running}>Start Count</button>
-      <button onClick={startRecognition} disabled={running}>Start Exercise</button>
-      <button onClick={stopTimer} disabled={!running}>Stop</button>
+      <div className="start-buttons">
+        <button className="start-count" onClick={startTimer} disabled={running}>Start Count</button>
+        <button className="start-exercise" onClick={startRecognition} disabled={running}>Start Exercise</button>
+      </div>
+      <button className="stop-button" onClick={stopTimer} disabled={!running}>Stop</button>
       <div>Time: {seconds}s</div>
       <h2>History</h2>
       <ul>


### PR DESCRIPTION
## Summary
- Restart speech recognition automatically while timer runs so "stop" command works reliably
- Separate start buttons into two columns with distinct colors for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68923c1937a083319f6d1471a1fb1cce